### PR TITLE
Made available the full response object in addition to the original a…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/
 *.log
+.idea

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ new Vue({
 
 	data:
 	{
-		output: {}, address: {}, sent: false
+		output: {}, address: {}, sent: false, response: {}, configs: {}
 	},
 
 
@@ -140,10 +140,11 @@ new Vue({
 		 * @param {Object}
 		 * @return {Void}
 		 */
-		onAddressChanged(address)
+		onAddressChanged(payload)
 		{
-			if (Object.keys(address).length > 0) {
-				this.address = address;
+			if (Object.keys(paypload.place).length > 0) {
+				this.address = payload.address;
+				this.response = payload.response;
 			}
 		}
 	}
@@ -179,9 +180,12 @@ See the example <a href="https://github.com/gocanto/google-autocomplete/blob/mas
 	class = "input"
 	input_id = "txtAutocomplete"
 	placeholder = "type your address"
+	:configs="{type: ['geocode']}"
 >
 </google-autocomplete>
 ```
+
+:configs is the configs passed to the Autocomplete constructor of the places API. See <a href="https://developers.google.com/maps/documentation/javascript/places-autocomplete#add_autocomplete">documentation</a>. Configs corresponds to the `options` argument in the doc.
 
 See the example <a href="https://github.com/gocanto/google-autocomplete/blob/master/demo/index.html#L50-L54" target="_blank">here</a>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -51,6 +51,7 @@
                         class = "input"
                         input_id = "txtAutocomplete"
                         placeholder = "type your address"
+                        :configs="{ type: ['geocode']}"
                     >
                     </google-autocomplete>
                     <span class="help is-danger" v-if="sent && isNotValid()">Select a valid address!</span>
@@ -73,7 +74,10 @@
             Address retrieved from google places
         </div>
         <div class="message-body">
+            <label>Output</label>
             <pre>{{ output }}</pre>
+            <label>Response</label>
+            <pre>{{ response }}</pre>
         </div>
     </article>
 

--- a/src/js/Components/googleAutocomplete.vue
+++ b/src/js/Components/googleAutocomplete.vue
@@ -11,11 +11,19 @@
 
 	export default {
 
-		props: [
-			'placeholder', //the input placeholder
-			'input_id', // the input id
-			'class' // the input class
-		],
+		props: {
+            placeholder: String, //the input placeholder
+            input_id: String, // the input id
+            "class": String, // the input class
+            configs: {
+              type: Object,
+              "default": () => {
+                return {
+                  types: ['geocode']
+                }
+              }
+            } // the Google Autocomplete configs to pass-in
+        },
 
 		data: function ()
 		{
@@ -50,14 +58,21 @@
 				}
 
 				return {};
-			}
+			},
+            response () {
+              if (this.hasAutocompleteInstance() && this.autocomplete.getPlace() !== null) {
+                return this.autocomplete.response;
+              }
+
+              return {};
+            }
 		},
 
 		mounted()
 		{
 			//Creates a new Autocomplete object and bind it to
 			//the given key.
-			this.autocomplete = Autocomplete.make(this.input_id);
+			this.autocomplete = Autocomplete.make(this.input_id, this.configs);
 		},
 
 		watch:
@@ -67,7 +82,10 @@
 				//fires an event to have the retrieved place within
 				//the parent component.
 				// Store.commit('setAddress', this.place);
-				Vuemit.fire('setAddress', this.place);
+				Vuemit.fire('setAddress', {
+                  place: this.place,
+                  response: this.response
+                });
 			}
 		},
 

--- a/src/js/Libraries/Autocomplete.js
+++ b/src/js/Libraries/Autocomplete.js
@@ -16,7 +16,7 @@ class Autocomplete
 	 * @param {String} ref
 	 * @return {Void}
 	 */
-	constructor(ref)
+	constructor(ref, configs = {})
 	{
 		/**
 		 * The retrieved place.
@@ -24,6 +24,13 @@ class Autocomplete
 		 * @type {Object}
 		 */
 		this.place = {};
+
+    /**
+     * The retrieved response
+     *
+     * @type {{}}
+     */
+		this.response = {};
 
 		/**
 		 * The autocomplete instance.
@@ -39,6 +46,13 @@ class Autocomplete
 		 */
 		this.ref = document.getElementById(ref);
 
+    /**
+     * The autocomplete configs
+     *
+     * @type {{}}
+     */
+    this.configs = configs;
+
 		//Boots the autocomplete.
 		this.boot();
 	}
@@ -47,9 +61,9 @@ class Autocomplete
 	 * Create a new google map instance.
 	 *
 	 */
-	static make(ref)
+	static make(ref, configs = {})
 	{
-		return new Autocomplete(ref);
+		return new Autocomplete(ref, configs);
 	}
 
 	/**
@@ -69,9 +83,7 @@ class Autocomplete
 	 */
 	bind(obj)
 	{
-		obj.autocomplete = new google.maps.places.Autocomplete(obj.ref, {
-			types: ['geocode']
-		});
+		obj.autocomplete = new google.maps.places.Autocomplete(obj.ref, this.configs);
 
 	    obj.autocomplete.addListener('place_changed', () => { obj.pipe(); });
 	}
@@ -102,6 +114,8 @@ class Autocomplete
 				JSON.stringify(data)
 			);
 		}
+
+		this.response = place;
 	}
 
 	/**

--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -44,7 +44,7 @@ require('./Components/index');
 
 window.GOOGLE_AUTOCOMPLETE = {
 	'domain': 'https://maps.googleapis.com/maps/api/js',
-	'key': 'AIzaSyBDBrWOEiYNTbOp05CoWBGuq4hIwAA6yEs',
+	'key': 'AIzaSyB669b125rYvqTQFK2jdkCmMAOPdGgUVEQ',
 	'library' : 'places',
 
 	// google inputs retrieved.

--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -44,7 +44,7 @@ require('./Components/index');
 
 window.GOOGLE_AUTOCOMPLETE = {
 	'domain': 'https://maps.googleapis.com/maps/api/js',
-	'key': 'AIzaSyB669b125rYvqTQFK2jdkCmMAOPdGgUVEQ',
+	'key': 'AIzaSyBDBrWOEiYNTbOp05CoWBGuq4hIwAA6yEs',
 	'library' : 'places',
 
 	// google inputs retrieved.

--- a/src/js/demo.js
+++ b/src/js/demo.js
@@ -14,7 +14,7 @@ new Vue({
 
 	data:
 	{
-		output: {}, address: {}, sent: false
+		output: {}, address: {}, sent: false, response: {}, configs: {}
 	},
 
 	mounted()
@@ -63,10 +63,11 @@ new Vue({
 		 * @param {Object}
 		 * @return {Void}
 		 */
-		onAddressChanged(address)
+		onAddressChanged(payload)
 		{
-			if (Object.keys(address).length > 0) {
-				this.address = address;
+			if (Object.keys(payload.place).length > 0) {
+				this.address = payload.place;
+				this.response = payload.response;
 			}
 		}
 	}


### PR DESCRIPTION
Warning
=
The callback payload interface has changed. 

Before
---
```
{
  "street_number": "...",
  "route": "...",
  "locality": "...",
  "administrative_area_level_1": "...",
  "country": "...",
  "postal_code": "..."
}
```

Now
---
```
{
  place: {
      "street_number": "...",
      "route": "...t",
      "locality": "...",
      "administrative_area_level_1": "...",
     "country": "...",
     "postal_code": "..."
   },
   response: { ... the original Google Autocomplete response ... }
}
```

Changes
==
- Made available the full response object in addition to the original address information already available in the callback
- Added the possibility to pass in the configs for the Autocomplete API
- Updated the doc to reflect those changes