### PR TITLE
Add addressWasCleared Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ new Vue({
 	{
 		//Set an event listener for 'setAddress'.
 		Vuemit.listen('setAddress', this.onAddressChanged);
+		Vuemit.listen('addressWasCleared', this.onAddressCleared);
 	},
 
 
@@ -135,7 +136,7 @@ new Vue({
 
 
 		/**
-		 * The callback fired when the autocomplete event was fired.
+		 * The callback fired when the autocomplete address change event was fired.
 		 *
 		 * @param {Object}
 		 * @return {Void}
@@ -147,6 +148,18 @@ new Vue({
 				this.response = payload.response;
 			}
 		}
+		
+		/**
+     * The callback fired when the autocomplete clear event was fired.
+     *
+     * @param {Object}
+     * @return {Void}
+     */
+    onAddressCleared()
+    {
+      this.address = {};
+      this.response = {};
+    }
 	}
 
 });

--- a/src/js/Components/googleAutocomplete.vue
+++ b/src/js/Components/googleAutocomplete.vue
@@ -90,7 +90,17 @@
 					response: this.response,
 					place: this.place
                 });
-			}
+			},
+
+            address()
+            {
+                if (this.address === '')
+                {
+                    //fires an event to let the parent component know the address field has been cleared
+                    Vuemit.fire('addressWasCleared');
+                }
+
+            }
 		},
 
 		methods:


### PR DESCRIPTION
Sometimes a parent component needs to reset its state when the address input field has been cleared. This PR adds that functionality.